### PR TITLE
Fix task used during sync to conform with PeeringDB's latest python version (v2.0.0).

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,8 +37,9 @@ pdb = Client(cfg={
 
 class SyncTask(threading.Thread):
     def run(self, *args, **kwargs):
+        rs = resource.all_resources()
         global last_sync
-        pdb.update_all()
+        pdb.updater.update_all(rs)
         last_sync = time.time()
 
 


### PR DESCRIPTION
Ran into an issue where the client version for peeringdb was outdated and causing sync to fail. Upon updating this to v2.0.0, it became apparent that the module for the sync task was incorrect as it was unable to locate the `update_all` module. This PR fixes both of these issues.